### PR TITLE
Fallback to unsupported extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/da_vinci/images.py
+++ b/da_vinci/images.py
@@ -92,7 +92,10 @@ class Image(object):
         """Generates a suitable filename based on image name and format."""
         name = self.filename or self.name
         filename, extension = os.path.splitext(name)
-        return '%s.%s' % (filename, formats.EXTENSIONS[self.format])
+        try:
+            return '%s.%s' % (filename, formats.EXTENSIONS[self.format])
+        except KeyError:
+            return name
 
     def show(self):
         """Displays the image, mainly for debugging purposes.


### PR DESCRIPTION
some people uploading their pictures that detected by Pillow as MPO format(image has jpg extensions), that's why i am not adding it into `EXTENSIONS` mapping, because the format and extension is somewhat inconsistent...
